### PR TITLE
Use playlist in video url to match jwpapp

### DIFF
--- a/includes/plugin.php
+++ b/includes/plugin.php
@@ -10,7 +10,7 @@ add_action( 'init', function() {
 
 	add_rewrite_rule( 'playlist/([^/]+)/?$', 'index.php?section=videos&playlist=$matches[1]', 'top' );
 
-	add_rewrite_rule( 'video/([^/]+)/?$', 'index.php?section=videos&video=$matches[1]', 'top' );
+	add_rewrite_rule( 'playlist/([^/]+)/video/([^/]+)/?$', 'index.php?section=videos&playlist=$matches[1]&video=$matches[2]', 'top' );
 
 });
 
@@ -63,7 +63,7 @@ add_filter( 'template_include', function( $template ) {
 	}
 
 	// Playlist
-	if ( ! empty( $playlist ) ) {
+	if ( ! empty( $playlist ) && '' === $video ) {
 		return apply_filters( 'jwshowcase_playlist_template', $playlist_template );
 	}
 
@@ -99,7 +99,7 @@ add_action( 'template_redirect', function() {
 	}
 
 	// Playlist
-	if ( '' !== $playlist ) {
+	if ( '' !== $playlist && '' === $video ) {
 
 		if ( ! JW_Showcase\get_playlist() ) {
 
@@ -109,9 +109,9 @@ add_action( 'template_redirect', function() {
 	}
 
 	// Video
-	if ( '' !== $video ) {
+	if ( '' !== $playlist && '' !== $video ) {
 
-		if ( ! JW_Showcase\get_video() ) {
+		if ( ! JW_Showcase\get_playlist() || ! JW_Showcase\get_video() ) {
 
 			return do_404();
 

--- a/templates/archive-video-playlist.php
+++ b/templates/archive-video-playlist.php
@@ -37,7 +37,7 @@ $playlist 	= JW_Showcase\get_playlist( $paylist_id );
 	<?php foreach ( $playlist->playlist as $video ) : ?>
 
 		<li class="jw-player-showcase-playlist-item">
-			<a href="<?php echo esc_url( home_url( '/video/' . $video->mediaid ) ); ?>">
+			<a href="<?php echo esc_url( home_url( '/playlist/' . $paylist_id . '/video/' . $video->mediaid ) ); ?>">
 				<img src="<?php echo esc_url( $video->image ); ?>" alt="<?php echo esc_attr( $video->title ); ?>" />
 			</a>
 		</li>

--- a/templates/single-video.php
+++ b/templates/single-video.php
@@ -6,6 +6,9 @@ $config 	= JW_Showcase\get_config();
 $video_id 	= JW_Showcase\get_video_id();
 $video 		= JW_Showcase\get_video( $video_id );
 
+$paylist_id = JW_Showcase\get_playlist_id();
+$playlist 	= JW_Showcase\get_playlist( $paylist_id );
+
 ?>
 
 <h1><?php echo esc_html( $config->siteName ); ?></h1>
@@ -19,5 +22,29 @@ $video 		= JW_Showcase\get_video( $video_id );
 		<img src="<?php echo esc_url( $video->image ); ?>" alt="<?php echo esc_attr( $video->title ); ?>" />
 	</div>
 </div>
+
+<?php if ( ! empty( $playlist->playlist ) ) : ?>
+
+<div class="jw-player-showcase-wrapper">
+
+	<h3><?php echo esc_html( $playlist->title ); ?></h3>
+
+	<ul class="jw-player-showcase-playlist">
+
+	<?php foreach ( $playlist->playlist as $video ) : ?>
+
+		<li class="jw-player-showcase-playlist-item">
+			<a href="<?php echo esc_url( home_url( '/playlist/' . $paylist_id . '/video/' . $video->mediaid ) ); ?>">
+				<img src="<?php echo esc_url( $video->image ); ?>" alt="<?php echo esc_attr( $video->title ); ?>" />
+			</a>
+		</li>
+
+	<?php endforeach; ?>
+
+	</ul>
+
+</div>
+
+<?php endif; ?>
 
 <?php get_footer();


### PR DESCRIPTION
## What Was Accomplished

- Updated rewrite rules to `/playlist/{playlist-id}/video/{video-id}` which matches the JW Player version of the app.
- Return 404 from a video page if the requested playlist is not found.
  - Consider returning the video with no playlist if the video is found but the playlist is not.

@Wendalf 