### PR TITLE
Change get_playlists based on new API JSON file

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -127,19 +127,15 @@ function get_playlists( $config = null ) {
 
 	}
 
-	if ( ! property_exists( $config, 'playlists' ) || ! is_array( $config->playlists ) ) {
+	$content = array();
 
-		$config->playlists = $playlists;
-
+	foreach ( $config->content as $value ) {
+		if ( true === property_exists( $value, 'playlistId' ) ) {
+			$content[] = $value->playlistId;
+		}
 	}
 
-	if ( property_exists( $config, 'featuredPlaylist' ) && is_string( $config->featuredPlaylist ) ) {
-
-		array_unshift( $config->playlists, $config->featuredPlaylist );
-
-	}
-
-	$playlists = array_map( __NAMESPACE__ . '\\get_playlist', $config->playlists );
+	$playlists = array_map( __NAMESPACE__ . '\\get_playlist', $content );
 
 	return $playlists;
 


### PR DESCRIPTION
JW Player changed the format of their API respond JSON file. Instead of 'playlists,' now it has an array of 'content' for us to get our showcase playlists:

`"content": [{"featured": true, "playlistId": "8HB4d8jG"}, {"playlistId": "udvTsg5m"}, {"playlistId": "aMD8uo3f"}, {"playlistId": "C39aGKGY"}]`